### PR TITLE
Feature remove dmarc report entry for same domain

### DIFF
--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -248,6 +248,15 @@ class Domain(Base):
             return f'_dmarc.{self.name}. 600 IN TXT "v=DMARC1; p=reject;{rua}{ruf} adkim=s; aspf=s"'
 
     @cached_property
+    def dns_dmarc_report_needed(self):
+        """ return true if DMARC report record is needed """
+        domain = app.config['DOMAIN']
+        if self.name != domain:
+            return True
+        else:
+            return False
+
+    @cached_property
     def dns_dmarc_report(self):
         """ return DMARC report record for mailu server """
         if self.dkim_key:
@@ -372,6 +381,15 @@ class Alternative(Base):
             ruf = app.config['DMARC_RUF']
             ruf = f' ruf=mailto:{ruf}@{domain};' if ruf else ''
             return f'_dmarc.{self.name}. 600 IN TXT "v=DMARC1; p=reject;{rua}{ruf} adkim=s; aspf=s"'
+
+    @cached_property
+    def dns_dmarc_report_needed(self):
+        """ return true if DMARC report record is needed """
+        domain = app.config['DOMAIN']
+        if self.name != domain:
+            return True
+        else:
+            return False
 
     @cached_property
     def dns_dmarc_report(self):

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -221,20 +221,20 @@ class Domain(Base):
     def dns_mx(self):
         """ return MX record for domain """
         hostname = app.config['HOSTNAME']
-        return f'{self.name}. 600 IN MX 10 {hostname}.'
+        return f'{idna.encode(self.name.lower()).decode('ascii')}. 600 IN MX 10 {idna.encode(hostname.lower()).decode('ascii')}.'
 
     @cached_property
     def dns_spf(self):
         """ return SPF record for domain """
         hostname = app.config['HOSTNAME']
-        return f'{self.name}. 600 IN TXT "v=spf1 mx a:{hostname} ~all"'
+        return f'{idna.encode(self.name.lower()).decode('ascii')}. 600 IN TXT "v=spf1 mx a:{idna.encode(hostname.lower()).decode('ascii')} ~all"'
 
     @property
     def dns_dkim(self):
         """ return DKIM record for domain """
         if self.dkim_key:
             selector = app.config['DKIM_SELECTOR']
-            return f'{selector}._domainkey.{self.name}. 600 IN TXT "v=DKIM1; k=rsa; p={self.dkim_publickey}"'
+            return f'{selector}._domainkey.{idna.encode(self.name.lower()).decode('ascii')}. 600 IN TXT "v=DKIM1; k=rsa; p={self.dkim_publickey}"'
 
     @cached_property
     def dns_dmarc(self):
@@ -242,10 +242,10 @@ class Domain(Base):
         if self.dkim_key:
             domain = app.config['DOMAIN']
             rua = app.config['DMARC_RUA']
-            rua = f' rua=mailto:{rua}@{domain};' if rua else ''
+            rua = f' rua=mailto:{rua}@{idna.encode(domain.lower()).decode('ascii')};' if rua else ''
             ruf = app.config['DMARC_RUF']
-            ruf = f' ruf=mailto:{ruf}@{domain};' if ruf else ''
-            return f'_dmarc.{self.name}. 600 IN TXT "v=DMARC1; p=reject;{rua}{ruf} adkim=s; aspf=s"'
+            ruf = f' ruf=mailto:{ruf}@{idna.encode(domain.lower()).decode('ascii')};' if ruf else ''
+            return f'_dmarc.{idna.encode(self.name.lower()).decode('ascii')}. 600 IN TXT "v=DMARC1; p=reject;{rua}{ruf} adkim=s; aspf=s"'
 
     @cached_property
     def dns_dmarc_report_needed(self):
@@ -261,7 +261,7 @@ class Domain(Base):
         """ return DMARC report record for mailu server """
         if self.dkim_key:
             domain = app.config['DOMAIN']
-            return f'{self.name}._report._dmarc.{domain}. 600 IN TXT "v=DMARC1;"'
+            return f'{idna.encode(self.name.lower()).decode('ascii')}._report._dmarc.{idna.encode(domain.lower()).decode('ascii')}. 600 IN TXT "v=DMARC1;"'
 
     @cached_property
     def dns_autoconfig(self):
@@ -282,10 +282,10 @@ class Domain(Base):
             ])
 
         return [
-            f'_{proto}._tcp.{self.name}. 600 IN SRV {prio} 1 {port} {hostname}.' if port in ports else f'_{proto}._tcp.{self.name}. 600 IN SRV 0 0 0 .'
+            f'_{proto}._tcp.{idna.encode(self.name.lower()).decode('ascii')}. 600 IN SRV {prio} 1 {port} {hostname}.' if port in ports else f'_{proto}._tcp.{idna.encode(self.name.lower()).decode('ascii')}. 600 IN SRV 0 0 0 .'
             for proto, port, prio
             in protocols
-        ]+[f'autoconfig.{self.name}. 600 IN CNAME {hostname}.', f'autodiscover.{self.name}. 600 IN CNAME {hostname}.']
+        ]+[f'autoconfig.{idna.encode(self.name.lower()).decode('ascii')}. 600 IN CNAME {idna.encode(hostname.lower()).decode('ascii')}.', f'autodiscover.{idna.encode(self.name.lower()).decode('ascii')}. 600 IN CNAME {idna.encode(hostname.lower()).decode('ascii')}.']
 
     @cached_property
     def dns_tlsa(self):
@@ -294,9 +294,9 @@ class Domain(Base):
         if app.config['TLS_FLAVOR'] in ('letsencrypt', 'mail-letsencrypt'):
             return [
                 # current ISRG Root X1 (RSA 4096, O = Internet Security Research Group, CN = ISRG Root X1) @20210902
-                f'_25._tcp.{hostname}. 86400 IN TLSA 2 1 1 0b9fa5a59eed715c26c1020c711b4f6ec42d58b0015e14337a39dad301c5afc3',
+                f'_25._tcp.{idna.encode(hostname.lower()).decode('ascii')}. 600 IN TLSA 2 1 1 0b9fa5a59eed715c26c1020c711b4f6ec42d58b0015e14337a39dad301c5afc3',
                 # current ISRG Root X2 (ECDSA P-384, O = Internet Security Research Group, CN = ISRG Root X2) @20240311
-                f'_25._tcp.{hostname}. 86400 IN TLSA 2 1 1 762195c225586ee6c0237456e2107dc54f1efc21f61a792ebd515913cce68332',
+                f'_25._tcp.{idna.encode(hostname.lower()).decode('ascii')}. 600 IN TLSA 2 1 1 762195c225586ee6c0237456e2107dc54f1efc21f61a792ebd515913cce68332',
             ]
         return []
 
@@ -369,7 +369,7 @@ class Alternative(Base):
         """ return DKIM record for domain """
         if self.domain.dkim_key:
             selector = app.config['DKIM_SELECTOR']
-            return f'{selector}._domainkey.{self.name}. 600 IN TXT "v=DKIM1; k=rsa; p={self.domain.dkim_publickey}"'
+            return f'{selector}._domainkey.{idna.encode(self.name.lower()).decode('ascii')}. 600 IN TXT "v=DKIM1; k=rsa; p={self.domain.dkim_publickey}"'
 
     @cached_property
     def dns_dmarc(self):
@@ -377,10 +377,10 @@ class Alternative(Base):
         if self.domain.dkim_key:
             domain = app.config['DOMAIN']
             rua = app.config['DMARC_RUA']
-            rua = f' rua=mailto:{rua}@{domain};' if rua else ''
+            rua = f' rua=mailto:{rua}@{idna.encode(domain.lower()).decode('ascii')};' if rua else ''
             ruf = app.config['DMARC_RUF']
-            ruf = f' ruf=mailto:{ruf}@{domain};' if ruf else ''
-            return f'_dmarc.{self.name}. 600 IN TXT "v=DMARC1; p=reject;{rua}{ruf} adkim=s; aspf=s"'
+            ruf = f' ruf=mailto:{ruf}@{idna.encode(domain.lower()).decode('ascii')};' if ruf else ''
+            return f'_dmarc.{idna.encode(self.name.lower()).decode('ascii')}. 600 IN TXT "v=DMARC1; p=reject;{rua}{ruf} adkim=s; aspf=s"'
 
     @cached_property
     def dns_dmarc_report_needed(self):
@@ -396,19 +396,19 @@ class Alternative(Base):
         """ return DMARC report record for mailu server """
         if self.domain.dkim_key:
             domain = app.config['DOMAIN']
-            return f'{self.name}._report._dmarc.{domain}. 600 IN TXT "v=DMARC1;"'
+            return f'{idna.encode(self.name.lower()).decode('ascii')}._report._dmarc.{idna.encode(domain.lower()).decode('ascii')}. 600 IN TXT "v=DMARC1;"'
 
     @cached_property
     def dns_mx(self):
         """ return MX record for domain """
         hostname = app.config['HOSTNAME']
-        return f'{self.name}. 600 IN MX 10 {hostname}.'
+        return f'{idna.encode(self.name.lower()).decode('ascii')}. 600 IN MX 10 {idna.encode(hostname.lower()).decode('ascii')}.'
 
     @cached_property
     def dns_spf(self):
         """ return SPF record for domain """
         hostname = app.config['HOSTNAME']
-        return f'{self.name}. 600 IN TXT "v=spf1 mx a:{hostname} ~all"'
+        return f'{idna.encode(self.name.lower()).decode('ascii')}. 600 IN TXT "v=spf1 mx a:{idna.encode(hostname.lower()).decode('ascii')} ~all"'
 
     def check_mx(self):
         """ checks if MX record for domain points to mailu host """

--- a/core/admin/mailu/ui/templates/domain/details.html
+++ b/core/admin/mailu/ui/templates/domain/details.html
@@ -44,7 +44,9 @@
   <th>{% trans %}DNS DMARC entry{% endtrans %}</th>
   <td>
     {{ macros.clip("dns_dmarc") }}<pre id="dns_dmarc" class="pre-config border bg-light">{{ domain.dns_dmarc }}</pre>
+    {%- if domain.dns_dmarc_report_needed %}
     {{ macros.clip("dns_dmarc_report") }}<pre id="dns_dmarc_report" class="pre-config border bg-light">{{ domain.dns_dmarc_report }}</pre>
+    {%- endif %}
   </td>
 </tr>
 {%- endif %}
@@ -89,7 +91,9 @@
   <th>{% trans %}DNS DMARC entry{% endtrans %}</th>
   <td>
     {{ macros.clip("dns_dmarc") }}<pre id="dns_dmarc" class="pre-config border bg-light">{{ alternative.dns_dmarc }}</pre>
+    {%- if alternative.dns_dmarc_report_needed %}
     {{ macros.clip("dns_dmarc_report") }}<pre id="dns_dmarc_report" class="pre-config border bg-light">{{ alternative.dns_dmarc_report }}</pre>
+    {%- endif %}
   </td>
 </tr>
 {%- endif %}

--- a/core/admin/mailu/ui/views/domains.py
+++ b/core/admin/mailu/ui/views/domains.py
@@ -81,7 +81,8 @@ def domain_download_zonefile(domain_name):
         txt = ' '.join(f'"{txt[p:p+250]}"' for p in range(0, len(txt), 250))
         res.append(f'{record} {txt}')
         res.append(domain.dns_dmarc)
-        res.append(domain.dns_dmarc_report)
+        if domain.dns_dmarc_report_needed:
+            res.append(domain.dns_dmarc_report)
     res.extend(domain.dns_tlsa)
     res.extend(domain.dns_autoconfig)
     for alternative in domain.alternatives:
@@ -92,7 +93,8 @@ def domain_download_zonefile(domain_name):
             txt = ' '.join(f'"{txt[p:p+250]}"' for p in range(0, len(txt), 250))
             res.append(f'{record} {txt}')
             res.append(alternative.dns_dmarc)
-            res.append(alternative.dns_dmarc_report)
+            if alternative.dns_dmarc_report_needed:
+                res.append(alternative.dns_dmarc_report)
     res.append("")
     return flask.Response(
         "\n".join(res),


### PR DESCRIPTION
When DMARC reports should be sent to an email address in another domain, the owner of the other domain has to give consent by adding a dns entry to his domain. But this holds true also the other way round: if the email address is from the same domain, the additional dns entry can be skipped. This PR checks if the email address is from the same domain and only shows the DNS entry for receiving DMARC reports if the domains do not match.