### PR TITLE
Feature add imprint

### DIFF
--- a/core/admin/mailu/configuration.py
+++ b/core/admin/mailu/configuration.py
@@ -64,6 +64,7 @@ DEFAULT_CONFIG = {
     # Web settings
     'SITENAME': 'Mailu',
     'WEBSITE': 'https://mailu.io',
+    'IMPRINT_URL': '',
     'ADMIN': 'none',
     'WEB_ADMIN': '/admin',
     'WEB_WEBMAIL': '/webmail',

--- a/core/admin/mailu/sso/templates/base_sso.html
+++ b/core/admin/mailu/sso/templates/base_sso.html
@@ -71,13 +71,22 @@
         </div>
       </div>
       <footer class="main-footer">
-        Built with <i class="fa fa-heart text-danger" aria-hidden="true"></i><span class="sr-only">love</span>
-        using <a href="https://flask.palletsprojects.com/">Flask</a>
-        and <a href="https://adminlte.io/themes/v3/index3.html">AdminLTE</a>.
-        <span class="fa-pull-right">
-          <i class="fa fa-code-branch" aria-hidden="true"></i><span class="sr-only">fork</span>
-          on <a href="https://github.com/Mailu/Mailu">Github</a>
-        </span>
+        <div class="d-flex flex-row justify-content-between">
+          <div class="p-2">
+            Built with <i class="fa fa-heart text-danger" aria-hidden="true"></i><span class="sr-only">love</span>
+            using <a href="https://flask.palletsprojects.com/">Flask</a>
+            and <a href="https://adminlte.io/themes/v3/index3.html">AdminLTE</a>.
+          </div>
+          {%- if config["IMPRINT_URL"] %}
+          <div class="p-2">
+            <a href="{{ config["IMPRINT_URL"] }}">Imprint / Impressum</a>
+          </div>
+          {%- endif %}
+          <div class="p-2">
+            <i class="fa fa-code-branch" aria-hidden="true"></i><span class="sr-only">fork</span>
+            on <a href="https://github.com/Mailu/Mailu">Github</a>
+          </div>
+        </div>
       </footer>
     </div>
     <script src="{{ url_for('static', filename='vendor.js') }}"></script>

--- a/core/admin/mailu/sso/templates/base_sso.html
+++ b/core/admin/mailu/sso/templates/base_sso.html
@@ -79,7 +79,7 @@
           </div>
           {%- if config["IMPRINT_URL"] %}
           <div class="p-2">
-            <a href="{{ config["IMPRINT_URL"] }}">Imprint / Impressum</a>
+            <a href="{{ config["IMPRINT_URL"] }}">{% trans %}Imprint{% endtrans %}</a>
           </div>
           {%- endif %}
           <div class="p-2">

--- a/core/admin/mailu/translations/da/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/da/LC_MESSAGES/messages.po
@@ -46,6 +46,10 @@ msgstr ""
 msgid "change language"
 msgstr ""
 
+#: mailu/sso/templates/base_sso.html:37 mailu/ui/templates/base.html:82
+msgid "Imprint"
+msgstr "Aftryk"
+
 #: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
 msgid "Go to"
 msgstr "Gå til"

--- a/core/admin/mailu/translations/de/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/de/LC_MESSAGES/messages.po
@@ -58,6 +58,10 @@ msgstr "Seitenleiste ein-/ausklapen"
 msgid "change language"
 msgstr "Sprachauswahl"
 
+#: mailu/sso/templates/base_sso.html:37 mailu/ui/templates/base.html:82
+msgid "Imprint"
+msgstr "Impressum"
+
 #: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr "Wechseln zu"

--- a/core/admin/mailu/translations/en/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/en/LC_MESSAGES/messages.po
@@ -62,6 +62,10 @@ msgstr ""
 msgid "change language"
 msgstr ""
 
+#: mailu/sso/templates/base_sso.html:37 mailu/ui/templates/base.html:82
+msgid "Imprint"
+msgstr ""
+
 #: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr ""

--- a/core/admin/mailu/translations/fr/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/fr/LC_MESSAGES/messages.po
@@ -42,6 +42,10 @@ msgstr ""
 msgid "change language"
 msgstr ""
 
+#: mailu/sso/templates/base_sso.html:37 mailu/ui/templates/base.html:82
+msgid "Imprint"
+msgstr "Imprimer"
+
 #: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
 msgid "Go to"
 msgstr "Navigation"

--- a/core/admin/mailu/translations/it/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/it/LC_MESSAGES/messages.po
@@ -42,6 +42,10 @@ msgstr ""
 msgid "change language"
 msgstr ""
 
+#: mailu/sso/templates/base_sso.html:37 mailu/ui/templates/base.html:82
+msgid "Imprint"
+msgstr "Impronta"
+
 #: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
 msgid "Go to"
 msgstr "Vai a"

--- a/core/admin/mailu/translations/nl/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/nl/LC_MESSAGES/messages.po
@@ -41,6 +41,10 @@ msgstr "Zijbalk in/uitklappen"
 msgid "change language"
 msgstr "kies taal"
 
+#: mailu/sso/templates/base_sso.html:37 mailu/ui/templates/base.html:82
+msgid "Imprint"
+msgstr "Afdruk"
+
 #: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
 msgid "Go to"
 msgstr "Ga naar"


### PR DESCRIPTION
## What type of PR?

Feature

## What does this PR do?

Some Mail services demand a link to a contact address on the website of the mail server (see for example: https://postmaster.t-online.de/#t4.1). Otherwise they do not accept e-mails from your mail-server. This can be achieved by adding an imprint to the SSO-login page.

### Related issue(s)
- Mention an issue like: #001
- Auto close an issue like: closes #001

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
