### PR TITLE
Fix date command for DMARC report cron job

### DIFF
--- a/core/rspamd/start.py
+++ b/core/rspamd/start.py
@@ -40,7 +40,7 @@ if os.environ.get('DMARC_SEND_REPORTS', 'false').lower() == 'true':
     with open('/etc/periodic/daily/dmarc-reports', 'w') as f:
         f.write('#!/bin/sh\n')
         f.write('# Send DMARC reports for yesterday\n')
-        f.write('su rspamd -s /bin/sh -c "/usr/bin/rspamadm dmarc_report $(date --date yesterday +%Y%m%d)" >/var/log/dmarc-reports.log 2>&1\n')
+        f.write('su rspamd -s /bin/sh -c "/usr/bin/rspamadm dmarc_report $(date -d @$(($(date -u +%s)-86400)) +%Y%m%d)" >/var/log/dmarc-reports.log 2>&1\n')
     # make executable
     os.chmod('/etc/periodic/daily/dmarc-reports', 0o755)
     # start crond


### PR DESCRIPTION
BusyBox date in Alpine doesn't support --date yesterday. Replace with: date -d @$(($(date -u +%s)-86400))

## What type of PR?

(Feature, enhancement, bug-fix, documentation)

## What does this PR do?

### Related issue(s)
- Mention an issue like: #001
- Auto close an issue like: closes #001

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
